### PR TITLE
[fix] change GET to POST in predict 

### DIFF
--- a/app/routers/predict.py
+++ b/app/routers/predict.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get(
+@router.post(
     "/btc",
     response_model=BaseResponse[List[BtcPredictionResp]],
     responses={400: {"model": ErrorResponse}},
@@ -31,7 +31,7 @@ async def predict(
     return HttpResponse(content=response_content)
 
 
-@router.get(
+@router.post(
     "/btc/product",
     response_model=BaseResponse[List[BtcPredictionResp]],
     responses={400: {"model": ErrorResponse}},

--- a/tests/app/router/test_predict_router.py
+++ b/tests/app/router/test_predict_router.py
@@ -26,7 +26,7 @@ async def test_predict_200(
     container.predict_service.override(predict_service_mock)
 
     url = "/v1/predict/btc"
-    response = await async_client.get(url)
+    response = await async_client.post(url)
     json_response = response.json()
 
     assert response.status_code == 200
@@ -77,7 +77,7 @@ async def test_predict_product_200(
     container.predict_service.override(predict_service_mock)
 
     url = "/v1/predict/btc/product"
-    response = await async_client.get(url)
+    response = await async_client.post(url)
     json_response = response.json()
     print(f"json_response : {json_response}")
 
@@ -126,7 +126,7 @@ async def test_predict_400(
         container.predict_service.override(predict_service_mock)
 
         url = "/v1/predict/btc"
-        response = await async_client.get(url)
+        response = await async_client.post(url)
         json_response = response.json()
 
         assert response.status_code == 400
@@ -175,7 +175,7 @@ async def test_predict_product_400(
         container.predict_service.override(predict_service_mock)
 
         url = "/v1/predict/btc/product"
-        response = await async_client.get(url)
+        response = await async_client.post(url)
         json_response = response.json()
 
         assert response.status_code == 400


### PR DESCRIPTION
## Overview
- get 으로 인한 파라미터 값들의 노출을 숨기기 위하여 GET에서 POST 로 변경하였습니다
    
## Change Log
- REST API METHOD get 에서  post 로 변경하였습니다
    
## To Reviewer
- 리뷰어가 유념해야 할 사항을 적어주세요.
- 특히, QA 테스트를 할 수 있도록 실행 방법 등을 기술해주세요.

## Acceptance Criteria

    
## Issue Tag
- Closed | Fixed: #1 
- See also: 
- [https://velog.io/@woojin98/GET-POST-왜-POST만-쓰지-않는-걸까](https://velog.io/@woojin98/GET-POST-%EC%99%9C-POST%EB%A7%8C-%EC%93%B0%EC%A7%80-%EC%95%8A%EB%8A%94-%EA%B1%B8%EA%B9%8C)](https://velog.io/@woojin98/GET-POST-%EC%99%9C-POST%EB%A7%8C-%EC%93%B0%EC%A7%80-%EC%95%8A%EB%8A%94-%EA%B1%B8%EA%B9%8C)

https://docs.mistral.ai/api/